### PR TITLE
change to space bar and change player movement

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -53,7 +53,7 @@ shot={
 }
 roll={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 weapon_next={

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -94,7 +94,7 @@ func _physics_process(delta):
 	position.x = clamp(position.x, 0, screen_size.x)
 	position.y = clamp(position.y, 0, screen_size.y)
 
-	move_and_slide()
+	position+=velocity*delta
 
 func _input(event):
 	if event is InputEventMouseMotion:


### PR DESCRIPTION
1. Changed roll button to space bar

2. Changed player script to move manually(position+=velocity*delta) instead of using move_and_slide. So the enemies don't push the players around anymore, and we can write our own logic for what happens when enemy touches the player