### PR TITLE
Added combat logic

### DIFF
--- a/scenes/enemy.tscn
+++ b/scenes/enemy.tscn
@@ -430,5 +430,14 @@ scale = Vector2(1.24572, 1.41643)
 color = Color(0.682353, 0.12549, 0.0705882, 1)
 polygon = PackedVector2Array(-19.266, -22.592, 0, -5.64801, 19.266, -22.592, 25.6879, -16.944, 6.42199, 0, 25.6879, 16.944, 19.266, 22.592, 0, 5.64801, -19.266, 22.592, -25.6879, 16.944, -6.42199, 0, -25.6879, -16.944)
 
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionShape2D2" type="CollisionShape2D" parent="Area2D"]
+light_mask = 3
+visibility_layer = 3
+scale = Vector2(0.99999994, 0.99999994)
+shape = SubResource("RectangleShape2D_3agpq")
+
 [connection signal="animation_finished" from="AnimationTree" to="." method="_on_animation_tree_animation_finished"]
 [connection signal="animation_finished" from="AnimationPlayer" to="." method="_on_animation_player_animation_finished"]
+[connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://bduw5gb057ino"]
+[gd_scene load_steps=34 format=4 uid="uid://bduw5gb057ino"]
 
 [ext_resource type="Script" uid="uid://bce6sj6kvwsh" path="res://scripts/game.gd" id="1_5vnjt"]
 [ext_resource type="Script" uid="uid://b7hpxdmpua5la" path="res://scripts/Camera/follow_camera.gd" id="2_0tnpc"]
@@ -12,6 +12,7 @@
 [ext_resource type="Texture2D" uid="uid://bgx2ojn3733h" path="res://assets/interior full/basics/grass.png" id="10_vtaks"]
 [ext_resource type="Script" uid="uid://bgs4chdd38ivf" path="res://scripts/pause_menu.gd" id="11_kvpfn"]
 [ext_resource type="FontFile" uid="uid://box1b2tla1jkp" path="res://assets/fonts/MegamaxJonathanToo-YqOq2.ttf" id="12_dinhu"]
+[ext_resource type="Script" uid="uid://dxygajgq6eycc" path="res://scripts/UI/health_label.gd" id="13_kvuet"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_trtic"]
 texture = ExtResource("2_gee14")
@@ -6844,5 +6845,14 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_kvuet")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_trtic")
 theme_override_styles/hover = SubResource("StyleBoxFlat_ir15t")
 text = "QUIT"
+
+[node name="HealthLabel" type="Label" parent="UI" node_paths=PackedStringArray("player")]
+offset_right = 40.0
+offset_bottom = 23.0
+theme_override_fonts/font = ExtResource("12_dinhu")
+theme_override_font_sizes/font_size = 32
+text = "Health: 100.0"
+script = ExtResource("13_kvuet")
+player = NodePath("../../Player")
 
 [connection signal="timeout" from="CameraSlowMoTimer" to="." method="_on_camera_slow_mo_timer_timeout"]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://bjxbgp7st5ob1" path="res://scripts/player.gd" id="1_sy1wy"]
 [ext_resource type="AudioStream" uid="uid://b5y5j2t81dq1l" path="res://assets/sound_effects/laserShoot.wav" id="2_qiobg"]
 [ext_resource type="Material" uid="uid://bcuo1xumj4tyr" path="res://assets/player_move_trail.tres" id="2_vodir"]
-[ext_resource type="PackedScene" uid="uid://c7ut3rlvimc6m" path="res://scenes/weapon.tscn" id="3_dqkch"]
+[ext_resource type="PackedScene" uid="uid://bpgjbxh7xb7s0" path="res://scenes/weapon.tscn" id="3_dqkch"]
 [ext_resource type="Texture2D" uid="uid://cyrqnx3ha4lux" path="res://assets/sound_effects/mom.png" id="3_qlg0r"]
 
 [sub_resource type="Animation" id="Animation_p6stl"]

--- a/scripts/UI/health_label.gd
+++ b/scripts/UI/health_label.gd
@@ -1,0 +1,12 @@
+extends Label
+
+@export var player: CharacterBody2D
+
+func _ready():
+	text = "Health: %d" % player.current_health
+	if player:
+		player.connect("health_changed", update_health)
+		update_health(player.current_health)
+
+func update_health(new_health):
+	text = "Health: %d" % new_health

--- a/scripts/UI/health_label.gd.uid
+++ b/scripts/UI/health_label.gd.uid
@@ -1,0 +1,1 @@
+uid://dxygajgq6eycc

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -4,11 +4,14 @@ signal enemy_destroyed(enemy)
 
 @export var health: int = 100
 @export var speed: float = 50.0
+@export var damage: float = 10.0
 
 var player: CharacterBody2D
 var push_dir: Vector2 = Vector2(0, 0)
 var push_strength: float = 0.0
 var push_timer: float = 0.0
+var bounce_timer: float = 0.0
+var default_bounce_timer: float = 0.25
 
 @onready var animation_tree: AnimationTree = $AnimationTree
 @onready var damage_text: Label = $DamageTextContainer/DamageText
@@ -24,7 +27,12 @@ func setup(pos: Vector2, _player: CharacterBody2D):
 
 func _physics_process(delta):
 	var dir = (player.global_position - global_position).normalized()
-	position += dir * delta * speed
+	bounce_timer = max(0.0,bounce_timer-delta)
+	#This feels hella clunky cuz the velocity jumps to 0 instead of decelerating ima make it work better later
+	if bounce_timer == 0.0: ##Basically if it's not currently bouncing then it will move
+		position += dir * delta * speed
+	elif bounce_timer >= 0.1: ##If the bounce timer is more than 0.1s it will bounce backwards. So for the last 0.1s after bouncing it will stand still to simulate recoil.
+		position -= dir * delta * speed * 2 ##IDEALLY it should linearly increase from -2 to 1(as a factor of the dir vector). Rather than jumping from -2 to 0 to 1. U got that Kyle
 	# Handle push
 	push_back(delta)
 
@@ -68,3 +76,9 @@ func _on_animation_player_animation_finished(anim_name):
 	if anim_name == "destroy":
 		#animation_tree['parameters/conditions/is_destroyed'] = false
 		pass
+
+#Logic for when the enemy collides with the player.
+func _on_area_2d_body_entered(body: Node2D) -> void:
+	if body == player and body.is_intangible == false:
+		player.take_damage(damage)
+		bounce_timer+=default_bounce_timer

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -3,15 +3,17 @@ extends CharacterBody2D
 @export var speed: float = 360.0
 @export var lr_flag: bool = true
 @export var rotate_flag: bool = true
-
+@export var max_health: float = 100.0
 # --- Roll system ---
 @export var roll_speed: float = 900.0
 @export var roll_time: float = 0.18
 @export var roll_cooldown: float = 0.4
+var 	current_health=max_health
 var is_rolling: bool = false
 var roll_timer: float = 0.0
 var roll_cd: float = 0.0
 var roll_dir: Vector2 = Vector2.ZERO
+var is_intangible: bool = false
 
 var screen_size
 var lr: bool = true
@@ -20,6 +22,8 @@ var is_shot_cd: bool = false
 var push_dir: Vector2 = Vector2.ZERO
 var push_strength: float = 0.0
 var push_timer: float = 0.0
+
+signal health_changed(new_health: int)
 
 @onready var body_lr: Polygon2D = $BodyLR
 @onready var body_rotate: Polygon2D = $BodyRotate
@@ -62,6 +66,7 @@ func _physics_process(delta):
 		roll_timer -= delta
 		if roll_timer <= 0.0:
 			is_rolling = false
+			is_intangible = false
 			roll_cd = roll_cooldown
 	else:
 		# Try to start a roll
@@ -72,6 +77,7 @@ func _physics_process(delta):
 				roll_dir = Vector2.RIGHT if lr else Vector2.LEFT
 
 			is_rolling = true
+			is_intangible = true
 			roll_timer = roll_time
 
 	# Use roll velocity if rolling
@@ -95,6 +101,14 @@ func _physics_process(delta):
 	position.y = clamp(position.y, 0, screen_size.y)
 
 	position+=velocity*delta
+	
+	# Damage and death logic
+	if current_health >= max_health:
+		current_health = max_health
+	if current_health <= 0.0:
+		current_health = 0.0
+		#Add death logic here
+		get_tree().quit()
 
 func _input(event):
 	if event is InputEventMouseMotion:
@@ -103,6 +117,10 @@ func _input(event):
 func setup(pos: Vector2):
 	position = pos
 	show()
+	
+func take_damage(amount: int) -> void:
+	current_health -= amount
+	emit_signal("health_changed", current_health)
 
 func update_body_lr():
 	if not lr_flag:


### PR DESCRIPTION
1. Giving the player health and death logic. There is a function for taking damage(pls use otherwise the health indicator won't update), an exported max_health variable and current_health variable. Currently when player health reaches 0 the game exits which is a placeholder behaviour. All in player.gd.

2. Enemy now has proper logic. It does 10 damage to the player on collision and bounces backwards. Bounce implementation is jank. All in enemy.gd. The enemy node now has a Area2D child node to handle collisions. In the future we can use this enemy logic as a basic enemy and adapt the script for other types of enemies.

3. Dodge roll now has intangibility, and enemy collision mechanics don't occur if you are intangible. This is a bool in player.gd. Intangibility check is handled in enemy.gd

4. Added a health indicator to the top left. This is just text, which is probably placeholder. This is the HealthLabel node in the UI node and health_label.gd.